### PR TITLE
Implement ingest CLI skeleton

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/example/treasurer/internal/config"
+	"github.com/example/treasurer/internal/database"
+	"github.com/example/treasurer/internal/ingest"
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "usage: %s <pdf>\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if flag.NArg() != 1 {
+		flag.Usage()
+		os.Exit(1)
+	}
+	path := flag.Arg(0)
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cfg := config.New()
+	db, err := database.New(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := db.Ping(); err != nil {
+		log.Fatal(err)
+	}
+
+	summary, err := ingest.ProcessFile(db, abs)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	out, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(out))
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.3
 
 require (
 	github.com/golang-migrate/migrate/v4 v4.18.3
+	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/lib/pq v1.10.9
 )
 

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728 h1:QwWKgMY28TAXaDl+ExRDqGQltzXqN/xypdKP86niVn8=
+github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728/go.mod h1:1fEHWurg7pvf5SG6XNE5Q8UZmOwex51Mkx3SLhrW5B4=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1,0 +1,131 @@
+package ingest
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	pdf "github.com/ledongthuc/pdf"
+)
+
+// Summary is returned upon successful ingestion.
+type Summary struct {
+	PeriodID             string `json:"period_id"`
+	PaymentsLoaded       int    `json:"payments_loaded"`
+	APInvoicesLoaded     int    `json:"ap_invoices_loaded"`
+	JournalEntriesLoaded int    `json:"journal_entries_loaded"`
+	JournalEntryLines    int    `json:"journal_entry_lines"`
+	CashAccountsUpdated  int    `json:"cash_accounts_updated"`
+	Validations          string `json:"validations"`
+}
+
+// ProcessFile ingests a single management-company PDF into the database.
+func ProcessFile(db *sql.DB, path string) (*Summary, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			tx.Rollback()
+		}
+	}()
+
+	pages, err := extractPages(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := classifyAll(pages); err != nil {
+		return nil, err
+	}
+
+	// TODO: invoke section parsers here
+
+	// TODO: perform validations here
+
+	summary := &Summary{
+		PeriodID:             detectPeriodFromFilename(path),
+		PaymentsLoaded:       0,
+		APInvoicesLoaded:     0,
+		JournalEntriesLoaded: 0,
+		JournalEntryLines:    0,
+		CashAccountsUpdated:  0,
+		Validations:          "PASSED",
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+	return summary, nil
+}
+
+// extractPages reads the PDF and returns plain text for each page.
+func extractPages(path string) ([]string, error) {
+	f, r, err := pdf.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var pages []string
+	total := r.NumPage()
+	for i := 1; i <= total; i++ {
+		p := r.Page(i)
+		if p.V.IsNull() {
+			continue
+		}
+		content, err := p.GetPlainText(nil)
+		if err != nil {
+			return nil, err
+		}
+		pages = append(pages, content)
+	}
+	return pages, nil
+}
+
+// classifyAll ensures each page can be classified according to rules.
+func classifyAll(pages []string) error {
+	for i, p := range pages {
+		if _, err := classifyPage(p); err != nil {
+			return fmt.Errorf("page %d: %w", i+1, err)
+		}
+	}
+	return nil
+}
+
+// classifyPage returns the section for a page based on header phrases.
+func classifyPage(text string) (string, error) {
+	upper := strings.ToUpper(text)
+	switch {
+	case strings.Contains(upper, "BALANCE SHEET"):
+		return "BALANCE_SHEET", nil
+	case strings.Contains(upper, "CASH DISBURSEMENTS JOURNAL"):
+		return "CDJ", nil
+	case strings.Contains(upper, "CASH FLOW DETAIL") || strings.Contains(upper, "RECEIPTS"):
+		return "CASH_FLOW", nil
+	case strings.Contains(upper, "UNPAID") && strings.Contains(upper, "INVOICE REGISTER"):
+		return "UNPAID_INV", nil
+	case strings.Contains(upper, "GENERAL JOURNAL"):
+		return "GJ", nil
+	case strings.Contains(upper, "DETAIL GENERAL LEDGER"):
+		return "DGL", nil
+	default:
+		return "", fmt.Errorf("unknown header")
+	}
+}
+
+// detectPeriodFromFilename returns the YYYY-MM prefix of the filename.
+func detectPeriodFromFilename(path string) string {
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	return strings.TrimSuffix(base, ext)
+}
+
+// MarshalJSON implements json.Marshaler for pretty printing.
+func (s *Summary) MarshalJSON() ([]byte, error) {
+	type Alias Summary
+	return json.MarshalIndent((*Alias)(s), "", "  ")
+}


### PR DESCRIPTION
## Summary
- create `ingest` CLI command that reads one PDF path
- add `internal/ingest` package with page extraction and classification stubs
- manage database transactions
- add pdf library dependency

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68869a36116c8327aa92c8a41f16a781